### PR TITLE
change dependencies of react ^15 to ^16 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   }
 }


### PR DESCRIPTION
Hi, we use your library in our project and updated react version from 15 to 16, after this actions library stopped work because of react version in dependencies. So, I fix it by changing version of it.

Are you still support it and how long does it take to to merge?
Thank's in advance)