### PR TITLE
Allow 10-digit numbers in Italy

### DIFF
--- a/src/country_data.js
+++ b/src/country_data.js
@@ -648,7 +648,7 @@ const rawAllCountries = [
     ['europe', 'european-union'],
     "it",
     "39",
-    "+.. ... ......",
+    "+.. ... .......",
     0
   ],
   [


### PR DESCRIPTION
Almost every Italian mobile number has 10 digit.