### PR TITLE
fix: make lib work inside shadow DOM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -651,7 +651,8 @@ class ReactPhoneInput extends React.Component {
   }
 
   handleClickOutside = (e) => {
-    if (this.dropdownRef && !this.dropdownContainerRef.contains(e.target)) {
+    const target = (e.composed && e.composedPath && e.composedPath().shift()) || e.target;
+    if (this.dropdownRef && !this.dropdownContainerRef.contains(target)) {
       this.state.showDropdown && this.setState({ showDropdown: false });
     }
   }


### PR DESCRIPTION
Hi, @bl00mber 
Thanks for the great phone input component.
We are trying to use this inside shadow DOM, but found an issue with the handleClickOutside function.
When rendering phone input inside shadow DOM, the e.target is always the host element when listening the events in document.
Thus the contains() is always false.

Change to get the real target element by using composedPath().