### PR TITLE
add autocompleteSearch option to disable/enable autocomplete on searc…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ class PhoneInput extends React.Component {
     value: PropTypes.string,
     placeholder: PropTypes.string,
     searchPlaceholder: PropTypes.string,
+    autocompleteSearch: Proptypes.bool,
     disabled: PropTypes.bool,
 
     containerStyle: PropTypes.object,
@@ -72,6 +73,7 @@ class PhoneInput extends React.Component {
     value: '',
     placeholder: '+1 (702) 123-4567',
     searchPlaceholder: 'search',
+    autocompleteSearch: false,
     flagsImagePath: './flags.png',
     disabled: false,
 
@@ -774,7 +776,7 @@ class PhoneInput extends React.Component {
 
   getCountryDropdownList = () => {
     const { preferredCountries, highlightCountryIndex, showDropdown, searchValue } = this.state;
-    const { enableSearchField, disableSearchIcon, searchClass, searchStyle, searchPlaceholder } = this.props;
+    const { enableSearchField, disableSearchIcon, searchClass, searchStyle, searchPlaceholder, autocompleteSearch } = this.props;
 
     const countryIsPreferred = this.state.preferredCountries.includes(this.state.selectedCountry);
     const searchedCountries = this.getSearchFilteredCountries()
@@ -852,6 +854,7 @@ class PhoneInput extends React.Component {
               type='search'
               placeholder={searchPlaceholder}
               autoFocus={true}
+              autoComplete={autocompleteSearch ? 'on' : 'off'}
               value={searchValue}
               onChange={this.handleSearchChange}
             />


### PR DESCRIPTION
When a autosuggestion for the input tag of search field according to previously entered values is displayed by browsers automatically, they look bad and make it hard to see/filter flags behind.

To overcome this problem, I've added an `autocompleteSearch` prop defaulting to false, which enables or disables autocomplete on the input tag of search field using `autoComplete="off"` if autocompleteSearch=false and `autoComplete="on"` if autocompleteSearch=true
