### PR TITLE
Fix Super expression must either be null or a function, not undefined

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,7 @@ if (TARGET === 'build' || TARGET === 'analyze') {
     optimization: {},
     output: {
       library: 'ReactPhoneInput',
-      libraryTarget: 'umd',
+      libraryTarget: 'commonjs2',
       globalObject: 'this'
     },
     module: {


### PR DESCRIPTION
I was receiving `Uncaught TypeError: Super expression must either be null or a function` when I used this module in a production build. I've seen the already existing and still open issue:
[Uncaught TypeError: Super expression must either be null or a function #126](https://github.com/bl00mber/react-phone-input-2/issues/126)

Tried different methods, and found out that using v2.9.5 did fix my issue but if I build that version myself, the same error happened again which made me think that version was built with an older version/different config of webpack. 

Digging deeper, I've found two very useful links:
https://stackoverflow.com/questions/33147379/external-react-component-cannot-see-react-component
https://tomasalabes.me/blog/web-development/2016/04/30/Webpack-Series-Part-1.html

I've changed the `libraryTarget: 'umd'` in the webpack config to `libraryTarget: 'commonjs2'`
which fixed the issue for me.

I wasn't able to fix it while keeping it umd, probably due to my lack of webpack experience. So, if keeping it as umd is important, do not merge this PR and look for other solutions.

However, in my use case and probably most people's, using it as commonjs2 should be fine.