### PR TITLE
Persist event for onChange handler.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -456,6 +456,8 @@ class PhoneInput extends React.Component {
     } else {
       e.returnValue = false;
     }
+    
+    if (this.props.onChange) e.persist();
 
     if (e.target.value.length > 0) {
       // before entering the number in new format, lets check if the dial code now matches some other country


### PR DESCRIPTION
Since the onChange event prop is called in a setState callback, based on the nature of a Synthetic event it won't be persisted when passed to the this.props.onChange call at line 500. In order to correctly pass the event as third argument, it should be persisted before any async operation, otherwise it'll be nullified.