### PR TITLE
Change label input behaviour

### DIFF
--- a/src/style/material.less
+++ b/src/style/material.less
@@ -45,7 +45,7 @@
       background: white;
       padding: 0 5px;
       font-size: 13px;
-      width: 70px;
+      white-space: nowrap;
     }
   }
   .flag-dropdown {


### PR DESCRIPTION
#199 

What I did and why?

The white-space is to never break-line

and removing the width it's to this behavior no happen:
With width:
![image](https://user-images.githubusercontent.com/17499030/77636430-df158980-6f32-11ea-9317-6cbb4d16a7d6.png)

Without width
![image](https://user-images.githubusercontent.com/17499030/77636503-fd7b8500-6f32-11ea-9b0b-f58a99007190.png)

Material has behavior to the line, not intersect the label,
Exemplo from Material-Ui docs
https://material-ui.com/components/text-fields/#textfield
![image](https://user-images.githubusercontent.com/17499030/77636614-2439bb80-6f33-11ea-9c16-32fd5984e4c4.png)

