### PR TITLE
Allow to disable initial country guess

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,10 @@ If `enableAreaCodeStretch` is added, the part of the mask with the area code wil
     <td> defaultErrorMessage </td>
     <td> string </td>
   </tr>
+  <tr>
+    <td> disableInitialCountryGuess </td>
+    <td> false </td>
+  </tr>
 </table>
 
 ### Custom localization

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class PhoneInput extends React.Component {
     countryCodeEditable: PropTypes.bool,
     enableSearch: PropTypes.bool,
     disableSearchIcon: PropTypes.bool,
-    disableCountryGuess: PropTypes.bool,
+    disableInitialCountryGuess: PropTypes.bool,
 
     regions: PropTypes.oneOfType([
       PropTypes.string,
@@ -124,7 +124,7 @@ class PhoneInput extends React.Component {
     countryCodeEditable: true,
     enableSearch: false,
     disableSearchIcon: false,
-    disableCountryGuess: false,
+    disableInitialCountryGuess: false,
 
     regions: '',
 
@@ -171,7 +171,7 @@ class PhoneInput extends React.Component {
     const inputNumber = props.value.replace(/\D/g, '') || '';
 
     let countryGuess;
-    if(props.disableCountryGuess){
+    if (props.disableInitialCountryGuess){
       countryGuess = 0;
     }else{
       if (inputNumber.length > 1) {

--- a/src/index.js
+++ b/src/index.js
@@ -171,19 +171,17 @@ class PhoneInput extends React.Component {
     const inputNumber = props.value.replace(/\D/g, '') || '';
 
     let countryGuess;
-    if (props.disableInitialCountryGuess){
+    if (props.disableInitialCountryGuess) {
       countryGuess = 0;
-    }else{
-      if (inputNumber.length > 1) {
-        // Country detect by phone
-        countryGuess = this.guessSelectedCountry(inputNumber.substring(0, 6), props.country, onlyCountries, hiddenAreaCodes) || 0;
-      } else if (props.country) {
-        // Default country
-        countryGuess = onlyCountries.find(o => o.iso2 == props.country) || 0;
-      } else {
-        // Empty params
-        countryGuess = 0;
-      }
+    } else if (inputNumber.length > 1) {
+      // Country detect by phone
+      countryGuess = this.guessSelectedCountry(inputNumber.substring(0, 6), props.country, onlyCountries, hiddenAreaCodes) || 0;
+    } else if (props.country) {
+      // Default country
+      countryGuess = onlyCountries.find(o => o.iso2 == props.country) || 0;
+    } else {
+      // Empty params
+      countryGuess = 0;
     }
 
     const dialCode = (

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ class PhoneInput extends React.Component {
     countryCodeEditable: PropTypes.bool,
     enableSearch: PropTypes.bool,
     disableSearchIcon: PropTypes.bool,
+    disableCountryGuess: PropTypes.bool,
 
     regions: PropTypes.oneOfType([
       PropTypes.string,
@@ -123,6 +124,7 @@ class PhoneInput extends React.Component {
     countryCodeEditable: true,
     enableSearch: false,
     disableSearchIcon: false,
+    disableCountryGuess: false,
 
     regions: '',
 
@@ -169,15 +171,19 @@ class PhoneInput extends React.Component {
     const inputNumber = props.value.replace(/\D/g, '') || '';
 
     let countryGuess;
-    if (inputNumber.length > 1) {
-      // Country detect by phone
-      countryGuess = this.guessSelectedCountry(inputNumber.substring(0, 6), props.country, onlyCountries, hiddenAreaCodes) || 0;
-    } else if (props.country) {
-      // Default country
-      countryGuess = onlyCountries.find(o => o.iso2 == props.country) || 0;
-    } else {
-      // Empty params
+    if(props.disableCountryGuess){
       countryGuess = 0;
+    }else{
+      if (inputNumber.length > 1) {
+        // Country detect by phone
+        countryGuess = this.guessSelectedCountry(inputNumber.substring(0, 6), props.country, onlyCountries, hiddenAreaCodes) || 0;
+      } else if (props.country) {
+        // Default country
+        countryGuess = onlyCountries.find(o => o.iso2 == props.country) || 0;
+      } else {
+        // Empty params
+        countryGuess = 0;
+      }
     }
 
     const dialCode = (

--- a/test/dev:js/demo.js
+++ b/test/dev:js/demo.js
@@ -95,6 +95,21 @@ class Demo extends React.Component {
             buttonStyle={{ borderRadius: '5px 0 0 5px' }}
             dropdownStyle={{ width: '300px' }}
           />
+          <p>Disable initial country guess</p>
+          <PhoneInput
+            value={'965555555'}
+            inputStyle={{
+              width: '300px',
+              height: '35px',
+              fontSize: '13px',
+              paddingLeft: '48px',
+              borderRadius: '5px'
+            }}
+            buttonStyle={{ borderRadius: '5px 0 0 5px' }}
+            dropdownStyle={{ width: '300px' }}
+            disableInitialCountryGuess
+          />
+
           <p>Customizable classes</p>
           <PhoneInput
             containerClass={'react-tel-input'}

--- a/test/dev:js/demo.js
+++ b/test/dev:js/demo.js
@@ -95,20 +95,6 @@ class Demo extends React.Component {
             buttonStyle={{ borderRadius: '5px 0 0 5px' }}
             dropdownStyle={{ width: '300px' }}
           />
-          <p>Disable initial country guess</p>
-          <PhoneInput
-            value={'965555555'}
-            inputStyle={{
-              width: '300px',
-              height: '35px',
-              fontSize: '13px',
-              paddingLeft: '48px',
-              borderRadius: '5px'
-            }}
-            buttonStyle={{ borderRadius: '5px 0 0 5px' }}
-            dropdownStyle={{ width: '300px' }}
-            disableInitialCountryGuess
-          />
 
           <p>Customizable classes</p>
           <PhoneInput

--- a/test/dev:js/demo.js
+++ b/test/dev:js/demo.js
@@ -95,7 +95,6 @@ class Demo extends React.Component {
             buttonStyle={{ borderRadius: '5px 0 0 5px' }}
             dropdownStyle={{ width: '300px' }}
           />
-
           <p>Customizable classes</p>
           <PhoneInput
             containerClass={'react-tel-input'}


### PR DESCRIPTION
### What has been done

This PR basically adds a new `disableInitialCountryGuess` prop that will disable the country guess from the `value` prop. This means that, we won't see any flag selected initially, something like:
![image](https://user-images.githubusercontent.com/347030/79452388-601ee880-7fe8-11ea-816b-92527b6370b4.png)
where we have a value set but no country guessed.

It's only the initial guess, if the user modifies the number the country will still be guessed as usual.

### Why do we need this?
In our database, we have many users with phones without country prefix. When we use that incomplete number with this component, the country is guessed but most of the times incorrectly. 

For example a typical Spanish number like: 965555555 is guessed as from Kuwait (country code: +965):
![image](https://user-images.githubusercontent.com/347030/79454284-37e4b900-7feb-11ea-9b7f-9b82c43afe70.png)

I think it's better to disable the country guessing in these cases (and let the user pick it) rather than show an incorrect number.
