### PR TITLE
Updating Types and Docs for onChange 

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,14 +244,24 @@ Country data object not returns from onKeyDown event
     <th> Description </th>
   </tr>
   <tr>
-    <td> value/event </td>
-    <td> string/object </td>
-    <td> event or the phone number </td>
+    <td> value </td>
+    <td> string </td>
+    <td> the phone number </td>
   </tr>
   <tr>
     <td> country data </td>
     <td> object </td>
     <td> country object { name, dialCode, countryCode (iso2) } </td>
+  </tr>
+  <tr>
+    <td> event </td>
+    <td> object </td>
+    <td> onChange event object </td>
+  </tr>
+  <tr>
+    <td> formattedValue </td>
+    <td> string </td>
+    <td> the formatted phone number </td>
   </tr>
 </table>
 
@@ -417,7 +427,7 @@ If `enableAreaCodeStretch` is added, the part of the mask with the area code wil
 ## Guides
 ### Phone without dialCode
 ```jsx
-handleOnChange(value, data, event) {
+handleOnChange(value, data, event, formattedValue) {
   this.setState({ rawPhone: value.slice(data.dialCode.length) })
 }
 ```

--- a/README.md
+++ b/README.md
@@ -244,24 +244,14 @@ Country data object not returns from onKeyDown event
     <th> Description </th>
   </tr>
   <tr>
-    <td> value </td>
-    <td> string </td>
-    <td> the phone number </td>
+    <td> value/event </td>
+    <td> string/object </td>
+    <td> event or the phone number </td>
   </tr>
   <tr>
     <td> country data </td>
     <td> object </td>
     <td> country object { name, dialCode, countryCode (iso2) } </td>
-  </tr>
-  <tr>
-    <td> event </td>
-    <td> object </td>
-    <td> onChange event object </td>
-  </tr>
-  <tr>
-    <td> formattedValue </td>
-    <td> string </td>
-    <td> the formatted phone number </td>
   </tr>
 </table>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,12 @@ declare module "react-phone-input-2" {
   }
 
   interface PhoneInputEventsProps {
-    onChange?(value: string, data: CountryData | {}): void;
+    onChange?(
+      value: string,
+      data: CountryData | {},
+      event: React.ChangeEvent<HTMLInputElement>,
+      formattedValue: string
+    ): void;
     onFocus?(
       event: React.FocusEvent<HTMLInputElement>,
       data: CountryData | {}


### PR DESCRIPTION
## Description
- updated parameter types to reflect new usage made by [these changes](https://github.com/bl00mber/react-phone-input-2/commit/5cf8e15b26b94effbc2c61565a9c147ff6640439)
- addresses the following error in typescript projects:
```
ERROR in [at-loader]  
    TS2322: Type '(value: any, country: any, e: any, formattedValue: any) => void' is not assignable to type '(value: string, data: {} | CountryData) => void'.
｢wdm｣: Failed to compile.
```

## Other Links
https://github.com/bl00mber/react-phone-input-2/pull/205#issuecomment-613574138
