### PR TITLE
countryCodeEditable prop not working for single digit country codes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -497,7 +497,7 @@ class PhoneInput extends React.Component {
       const mainCode = newSelectedCountry.hasAreaCodes ?
         this.state.onlyCountries.find(o => o.iso2 === newSelectedCountry.iso2 && o.mainCode).dialCode :
         newSelectedCountry.dialCode;
-      
+
       const updatedInput = prefix+mainCode;
       if (value.slice(0, updatedInput.length) !== updatedInput) return;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -495,8 +495,8 @@ class PhoneInput extends React.Component {
     
     if (!this.props.countryCodeEditable) {
       const mainCode = newSelectedCountry.hasAreaCodes ?
-      this.state.onlyCountries.find(o => o.iso2 === newSelectedCountry.iso2 && o.mainCode).dialCode :
-      newSelectedCountry.dialCode;
+        this.state.onlyCountries.find(o => o.iso2 === newSelectedCountry.iso2 && o.mainCode).dialCode :
+        newSelectedCountry.dialCode;
       
       const updatedInput = prefix+mainCode;
       if (value.slice(0, updatedInput.length) !== updatedInput) return;

--- a/src/index.js
+++ b/src/index.js
@@ -489,22 +489,21 @@ class PhoneInput extends React.Component {
     const { value } = e.target;
     const { prefix } = this.props;
 
-    if (value === prefix) return this.setState({ formattedNumber: '' });
-
     let formattedNumber = this.props.disableCountryCode ? '' : prefix;
     let newSelectedCountry = this.state.selectedCountry;
     let freezeSelection = this.state.freezeSelection;
-
-
+    
     if (!this.props.countryCodeEditable) {
       const mainCode = newSelectedCountry.hasAreaCodes ?
-        this.state.onlyCountries.find(o => o.iso2 === newSelectedCountry.iso2 && o.mainCode).dialCode :
-        newSelectedCountry.dialCode;
-
+      this.state.onlyCountries.find(o => o.iso2 === newSelectedCountry.iso2 && o.mainCode).dialCode :
+      newSelectedCountry.dialCode;
+      
       const updatedInput = prefix+mainCode;
       if (value.slice(0, updatedInput.length) !== updatedInput) return;
     }
-
+    
+    if (value === prefix) return this.setState({ formattedNumber: '' });
+    
     // Does not exceed 15 digit phone number limit
     if (value.replace(/\D/g, '').length > 15 && !this.state.enableLongNumbers) return;
 


### PR DESCRIPTION
Issue: https://github.com/bl00mber/react-phone-input-2/issues/222

When the countryCodeEditable prop is set to false, country codes with a single digit can be deleted. Once deleted, values cannot be entered afterward.

Because the country code is a single digit, pressing delete returns a value equal to the prefix and handleInput is returned rather than entering the countryCodeEditable code block.
