### PR TITLE
Screenreader/keyboard accessibility attributes, styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -647,7 +647,7 @@ class PhoneInput extends React.Component {
     const { keys } = this.props;
     const { target: { className } } = e;
 
-    if (className.includes('flag-dropdown') && e.which === keys.ENTER && !this.state.showDropdown) return this.handleFlagDropdownClick();
+    if (className.includes('selected-flag') && e.which === keys.ENTER && !this.state.showDropdown) return this.handleFlagDropdownClick();
     if (className.includes('form-control') && (e.which === keys.ENTER || e.which === keys.ESC)) return e.target.blur();
 
     if (!this.state.showDropdown || this.props.disabled) return;
@@ -766,11 +766,12 @@ class PhoneInput extends React.Component {
     const searchedCountries = this.getSearchFilteredCountries()
 
     let countryDropdownList = searchedCountries.map((country, index) => {
+      const highlight = highlightCountryIndex === index;
       const itemClasses = classNames({
         country: true,
         preferred: country.iso2 === 'us' || country.iso2 === 'gb',
         active: country.iso2 === 'us',
-        highlight: highlightCountryIndex === index
+        highlight
       });
 
       const inputFlagClasses = `flag ${country.iso2}`;
@@ -785,6 +786,8 @@ class PhoneInput extends React.Component {
           tabIndex={disableDropdown ? '-1' : '0'}
           data-country-code={country.iso2}
           onClick={(e) => this.handleFlagItemClick(country, e)}
+          role='option'
+          {... highlight ? { "aria-selected": true } : {}}
         >
           <div className={inputFlagClasses}/>
           <span className='country-name'>{this.getDropdownCountryName(country)}</span>
@@ -806,9 +809,14 @@ class PhoneInput extends React.Component {
 
     return (
       <ul
-        ref={el => this.dropdownRef = el}
+        ref={el => {
+          !enableSearch && el && el.focus();
+          return (this.dropdownRef = el);
+        }}
         className={dropDownClasses}
         style={this.props.dropdownStyle}
+        role='listbox'
+        tabIndex='0'
       >
         {enableSearch && (
           <li
@@ -923,8 +931,6 @@ class PhoneInput extends React.Component {
           className={flagViewClasses}
           style={this.props.buttonStyle}
           ref={el => this.dropdownContainerRef = el}
-          tabIndex={disableDropdown ? '-1' : '0'}
-          role='button'
         >
           {renderStringAsFlag ?
           <div className={selectedFlagClasses}>{renderStringAsFlag}</div>
@@ -933,6 +939,10 @@ class PhoneInput extends React.Component {
             onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
             className={selectedFlagClasses}
             title={selectedCountry ? `${selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
+            tabIndex={disableDropdown ? '-1' : '0'}
+            role='button'
+            aria-haspopup="listbox"
+            aria-expanded={showDropdown ? true : undefined}
           >
             <div className={inputFlagClasses}>
               {!disableDropdown && <div className={arrowClasses}></div>}

--- a/src/style/bootstrap.less
+++ b/src/style/bootstrap.less
@@ -26,7 +26,6 @@
     }
   }
   .flag-dropdown {
-    outline: none;
     position: absolute;
     top: 0;
     bottom: 0;
@@ -55,6 +54,25 @@
     height: 100%;
     padding: 0 0 0 11px;
     border-radius: 3px 0 0 3px;
+    outline: none;
+    &:before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 2px;
+      bottom: 2px;
+      left: 0;
+      width: 100%;
+      border-radius: 4px 2px 2px 4px;
+      border: 1px solid transparent;
+      transition: box-shadow ease .25s, border-color ease .25s;
+    }
+    &:focus {
+      &:before {
+        border-color: #80bdff;
+        box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+      }
+    }
     .flag {
       position: absolute;
       top: 50%;
@@ -88,6 +106,7 @@
     max-height: 220px;
     overflow-y: scroll;
     border-radius: 7px;
+    outline: none;
     .flag {
       display: inline-block;
       position: absolute;

--- a/src/style/high-res.less
+++ b/src/style/high-res.less
@@ -32,7 +32,6 @@
     }
   }
   .flag-dropdown {
-    outline: none;
     position: absolute;
     top: 0;
     bottom: 0;
@@ -40,6 +39,7 @@
     background-color: #f5f5f5;
     border: 1px solid #cacaca;
     border-radius: 3px 0 0 3px;
+    cursor: pointer;
     &.open {
       z-index: 2;
       background: #fff;
@@ -47,12 +47,6 @@
       .selected-flag {
         background: #fff;
         border-radius: 3px 0 0 0;
-      }
-    }
-    &:hover, &:focus {
-      cursor: pointer;
-      .selected-flag {
-        background-color: #fff;
       }
     }
   }
@@ -72,6 +66,11 @@
     height: 100%;
     padding: 0 0 0 8px;
     border-radius: 3px 0 0 3px;
+    outline: none;
+    cursor: pointer;
+    &:hover, &:focus {
+      background-color: #fff;
+    }
     .flag {
       position: absolute;
       top: 50%;
@@ -105,6 +104,7 @@
     max-height: 224px;
     overflow-y: scroll;
     border-radius: 0 0 3px 3px;
+    outline: none;
     .flag {
       display: inline-block;
       position: absolute;

--- a/src/style/material.less
+++ b/src/style/material.less
@@ -43,10 +43,10 @@
       padding: 0 5px;
       font-size: 13px;
       white-space: nowrap;
+      z-index: 1;
     }
   }
   .flag-dropdown {
-    outline: none;
     position: absolute;
     top: 0;
     bottom: 0;
@@ -75,6 +75,25 @@
     height: 100%;
     padding: 0 0 0 11px;
     border-radius: 3px 0 0 3px;
+    outline: none;
+    &:before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 2px;
+      bottom: 2px;
+      left: 0;
+      width: 100%;
+      border-radius: 4px 0 0 4px;
+      border: 1px solid transparent;
+      transition: box-shadow ease .25s, border-color ease .25s;
+    }
+    &:focus {
+      &:before {
+        border-color: #1976d2;
+        box-shadow: 0 0 0 1px #1976d2;
+      }
+    }
     .flag {
       position: absolute;
       top: 50%;
@@ -108,6 +127,7 @@
     max-height: 220px;
     overflow-y: scroll;
     border-radius: 7px;
+    outline: none;
     .flag {
       display: inline-block;
       position: absolute;

--- a/src/style/plain.less
+++ b/src/style/plain.less
@@ -33,18 +33,10 @@
     bottom: 0;
     padding: 0;
     border: 1px solid #cacaca;
+    cursor: pointer;
     &.open {
       z-index: 2;
       background: #fff;
-      .selected-flag {
-        background: #fff;
-      }
-    }
-    &:hover, &:focus, &.open {
-      cursor: pointer;
-      .selected-flag {
-        background-color: #f5f5f5;
-      }
     }
   }
   input[disabled] {
@@ -63,6 +55,10 @@
     height: 100%;
     padding: 0 0 0 8px;
     border-radius: 3px 0 0 3px;
+    cursor: pointer;
+    &:hover, &:focus, &.open {
+      background-color: #f5f5f5;
+    }
     .flag {
       position: absolute;
       top: 50%;
@@ -95,6 +91,7 @@
     width: 300px;
     max-height: 282px;
     overflow-y: scroll;
+    outline: none;
     .flag {
       display: inline-block;
     }

--- a/src/style/semantic-ui.less
+++ b/src/style/semantic-ui.less
@@ -38,7 +38,6 @@
     }
   }
   .flag-dropdown {
-    outline: none;
     position: absolute;
     top: 0;
     bottom: 0;
@@ -46,18 +45,13 @@
     background-color: #f5f5f5;
     border: 1px solid #cacaca;
     border-radius: 3px 0 0 3px;
+    cursor: pointer;
     &.open {
       background: #fff;
       border-radius: 3px 0 0 0;
       .selected-flag {
         background: #fff;
         border-radius: 3px 0 0 0;
-      }
-    }
-    &:hover, &:focus {
-      cursor: pointer;
-      .selected-flag {
-        background-color: #fff;
       }
     }
   }
@@ -77,6 +71,11 @@
     height: 100%;
     padding: 0 0 0 8px;
     border-radius: 3px 0 0 3px;
+    outline: none;
+    cursor: pointer;
+    &:hover, &:focus {
+      background-color: #fff;
+    }
     .flag {
       position: absolute;
       top: 50%;
@@ -115,6 +114,7 @@
     width: 300px;
     max-height: 200px;
     overflow-y: scroll;
+    outline: none;
     .flag {
       display: inline-block;
     }

--- a/src/style/style.less
+++ b/src/style/style.less
@@ -28,7 +28,6 @@
     }
   }
   .flag-dropdown {
-    outline: none;
     position: absolute;
     top: 0;
     bottom: 0;
@@ -36,6 +35,7 @@
     background-color: #f5f5f5;
     border: 1px solid #cacaca;
     border-radius: 3px 0 0 3px;
+    cursor: pointer;
     &.invalid-number {
       border-color: #d79f9f;
     }
@@ -46,12 +46,6 @@
       .selected-flag {
         background: #fff;
         border-radius: 3px 0 0 0;
-      }
-    }
-    &:hover, &:focus {
-      cursor: pointer;
-      .selected-flag {
-        background-color: #fff;
       }
     }
   }
@@ -71,6 +65,11 @@
     height: 100%;
     padding: 0 0 0 8px;
     border-radius: 3px 0 0 3px;
+    outline: none;
+    cursor: pointer;
+    &:hover, &:focus {
+      background-color: #fff;
+    }
     .flag {
       position: absolute;
       top: 50%;
@@ -104,6 +103,7 @@
     max-height: 200px;
     overflow-y: scroll;
     border-radius: 0 0 3px 3px;
+    outline: none;
     .flag {
       display: inline-block;
     }


### PR DESCRIPTION
Here are the changes I suggested [here](https://github.com/bl00mber/react-phone-input-2/issues/250):

- Moving the button ARIA role and button behaviour down to the selected-flag div
- Additional ARIA attributes
- CSS changes, to keep everything looking the same
- added country selector focus states on the material and bootstrap themes (based on the styling for their respective input fields)