### PR TITLE
Add disableInitialCountryGuess to Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,6 +98,7 @@ declare module "react-phone-input-2" {
     showDropdown?: boolean;
 
     defaultErrorMessage?: string;
+    disableInitialCountryGuess?: boolean;
   }
   const PhoneInput: React.FC<PhoneInputProps>;
   export default PhoneInput;


### PR DESCRIPTION
The property was added in https://github.com/bl00mber/react-phone-input-2/pull/212 but wasn't added to the Typescript definition.