### PR TITLE
Add custom input component prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import memoize from 'lodash.memoize';
@@ -8,6 +8,8 @@ import classNames from 'classnames';
 import './utils/prototypes'
 
 import CountryData from './CountryData.js';
+
+const DefaultInput = forwardRef((props, ref) => (<input {...props} ref={ref} />));
 
 class PhoneInput extends React.Component {
   static propTypes = {
@@ -933,6 +935,8 @@ class PhoneInput extends React.Component {
     });
     const inputFlagClasses = `flag ${selectedCountry && selectedCountry.iso2}`;
 
+    const Input = this.props.component ? this.props.component : DefaultInput;
+
     return (
       <div
         className={containerClasses}
@@ -940,8 +944,8 @@ class PhoneInput extends React.Component {
         onKeyDown={this.handleKeydown}>
         {specialLabel && <div className='special-label'>{specialLabel}</div>}
         {errorMessage && <div className='invalid-number-message'>{errorMessage}</div>}
-        <input
-          className={inputClasses}
+        <Input
+          className={!this.props.component && inputClasses}
           style={this.props.inputStyle}
           onChange={this.handleInput}
           onClick={this.handleInputClick}


### PR DESCRIPTION
This allows rendering a customized input component. If a component prop is
found, it will omit default className applied to avoid custom component styles conflicting with the default ones.

```js
              <PhoneInput
                country={'us'}
                preferredCountries={['us']}
                placeholder="Phone"
                value={user.phone}
                component={CustomFancyInput}
              />
```

Related to #113. I believe it's the simplest approach to implement this, by allowing the consumer to bypass the default input entirely without losing any functionality.