### PR TITLE
dropdownContainer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,34 @@ import 'react-phone-input-2/lib/style.css'
     <td> object </td>
     <td colspan="2"> props to pass into the input </td>
   </tr>
+
+  <tr>
+    <td> dropdownContainerId </td>
+    <td> string </td>
+    <td colspan="2"> id of container where flags dropdown would be put(eg. useful for using component in modals).<br/>
+    If component with passed id doesn't exist, dropdown will be appended as last child of body.<br/>
+    <i>uses React.Portal, so React 16+ version is required</i>
+    </td>
+  </tr>
+
+  <tr>
+    <td> dropdownContainerClass </td>
+    <td> string </td>
+    <td colspan="2"> class name that will be passed to dropdown container(if <b>dropdownContainerId</b> is set)<br/>
+    It could be used to style or adjust positioning.
+    </td>
+  </tr>
+
+  <tr>
+    <td> dropdownContainerStyle </td>
+    <td> {[name: DOMString]: any} </td>
+    <td>
+    It could be used to style or adjust positioning directly without creating CSS class(if <b>dropdownContainerId</b> is set).
+    </td>
+    <td>
+        { 'z-index': 10000, 'font-weight': 600 }}
+    </td>
+  </tr>
 </table>
 
 <table>

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,9 @@ declare module "react-phone-input-2" {
     enableAreaCodeStretch?: boolean;
     enableClickOutside?: boolean;
     showDropdown?: boolean;
+    dropdownContainerId?: string,
+    dropdownContainerClass?: string,
+    dropdownContainerStyle?: { [k: string]: any },
 
     defaultErrorMessage?: string;
     specialLabel?: string;

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { DROPDOWN_ID } from "./index";
+
+const Portal = ({dropdownContainerId, dropdownContainerClass = '', dropdownContainerStyle, coords, children}) => {
+  let mount = document.getElementById(dropdownContainerId);
+  if (!mount) {
+    mount = document.body;
+  }
+  const el = document.createElement("div");
+  el.id = DROPDOWN_ID;
+  el.className = `react-tel-input ${dropdownContainerClass}`.trim();
+  if (dropdownContainerStyle) {
+    Object.keys(dropdownContainerStyle).map(key => el.style.setProperty(key, dropdownContainerStyle[key]));
+  }
+  el.style.setProperty('position',`absolute`);
+  el.style.setProperty('width', `auto`);
+  el.style.setProperty('top', `${coords.top}px`);
+  el.style.setProperty('left', `${coords.left}px`);
+
+  useEffect(() => {
+    mount.appendChild(el);
+    return () => mount.removeChild(el);
+  }, [el, mount]);
+
+  return createPortal(children, el)
+};
+
+export default Portal;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ import classNames from 'classnames';
 import './utils/prototypes'
 
 import CountryData from './CountryData.js';
+import Portal from './Portal';
+
+export const DROPDOWN_ID = `react-tel-input-portal`;
 
 class PhoneInput extends React.Component {
   static propTypes = {
@@ -84,6 +87,9 @@ class PhoneInput extends React.Component {
     enableAreaCodeStretch: PropTypes.bool,
     enableClickOutside: PropTypes.bool,
     showDropdown: PropTypes.bool,
+    dropdownContainerId: PropTypes.string,
+    dropdownContainerClass: PropTypes.string,
+    dropdownContainerStyle: PropTypes.object,
 
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
@@ -204,10 +210,10 @@ class PhoneInput extends React.Component {
 
     let formattedNumber;
     formattedNumber = (inputNumber === '' && countryGuess === 0) ? '' :
-    this.formatNumber(
-      (props.disableCountryCode ? '' : dialCode) + inputNumber,
-      countryGuess.name ? countryGuess : undefined
-    );
+      this.formatNumber(
+        (props.disableCountryCode ? '' : dialCode) + inputNumber,
+        countryGuess.name ? countryGuess : undefined
+      );
 
     const highlightCountryIndex = onlyCountries.findIndex(o => o == countryGuess);
 
@@ -680,10 +686,10 @@ class PhoneInput extends React.Component {
     if (className.includes('search-box')) {
       if (e.which !== keys.UP && e.which !== keys.DOWN && e.which !== keys.ENTER) {
         if (e.which === keys.ESC && e.target.value === '') {
-         // do nothing // if search field is empty, pass event (close dropdown)
-       } else {
-         return; // don't process other events coming from the search field
-       }
+          // do nothing // if search field is empty, pass event (close dropdown)
+        } else {
+          return; // don't process other events coming from the search field
+        }
       }
     }
 
@@ -737,7 +743,13 @@ class PhoneInput extends React.Component {
   }
 
   handleClickOutside = (e) => {
-    if (this.dropdownRef && !this.dropdownContainerRef.contains(e.target)) {
+    let dropdownContainer = this.dropdownContainerRef;
+    const { dropdownContainerId } = this.props;
+
+    if (dropdownContainerId) {
+      dropdownContainer = document.querySelector(`#${DROPDOWN_ID}`) || document.body;
+    }
+    if (this.dropdownRef && !dropdownContainer.contains(e.target)) {
       this.state.showDropdown && this.setState({ showDropdown: false });
     }
   }
@@ -769,7 +781,7 @@ class PhoneInput extends React.Component {
       // [...new Set()] to get rid of duplicates
       // firstly search by iso2 code
       if (/^\d+$/.test(sanitizedSearchValue)) { // contains digits only
-         // values wrapped in ${} to prevent undefined
+        // values wrapped in ${} to prevent undefined
         return allCountries.filter(({ dialCode }) =>
           [`${dialCode}`].some(field => field.toLowerCase().includes(sanitizedSearchValue)))
       } else {
@@ -856,14 +868,14 @@ class PhoneInput extends React.Component {
             })}
           >
             {!disableSearchIcon &&
-              <span
-                className={classNames({
-                  'search-emoji': true,
-                  [`${searchClass}-emoji`]: searchClass,
-                })}
-                role='img'
-                aria-label='Magnifying glass'
-              >
+            <span
+              className={classNames({
+                'search-emoji': true,
+                [`${searchClass}-emoji`]: searchClass,
+              })}
+              role='img'
+              aria-label='Magnifying glass'
+            >
                 &#128270;
               </span>}
             <input
@@ -890,6 +902,31 @@ class PhoneInput extends React.Component {
           )}
       </ul>
     );
+  }
+
+  showDropdown = () => {
+    const { dropdownContainerId, dropdownContainerClass, dropdownContainerStyle } = this.props;
+    if (dropdownContainerId) {
+      if (this.dropdownContainerRef) {
+        const rect = this.dropdownContainerRef && this.dropdownContainerRef.getBoundingClientRect();
+        const coords = {
+          left: rect.x, // small position adjustment
+          top: rect.y + window.scrollY + rect.height / 2,
+        }
+
+        return (
+          <Portal
+            dropdownContainerId={dropdownContainerId}
+            dropdownContainerClass={dropdownContainerClass}
+            dropdownContainerStyle={dropdownContainerStyle}
+            coords={coords}
+          >
+            {this.getCountryDropdownList()}
+          </Portal>
+        );
+      }
+    }
+    return this.getCountryDropdownList();
   }
 
   render() {
@@ -964,23 +1001,23 @@ class PhoneInput extends React.Component {
           ref={el => this.dropdownContainerRef = el}
         >
           {renderStringAsFlag ?
-          <div className={selectedFlagClasses}>{renderStringAsFlag}</div>
-          :
-          <div
-            onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
-            className={selectedFlagClasses}
-            title={selectedCountry ? `${selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
-            tabIndex={disableDropdown ? '-1' : '0'}
-            role='button'
-            aria-haspopup="listbox"
-            aria-expanded={showDropdown ? true : undefined}
-          >
-            <div className={inputFlagClasses}>
-              {!disableDropdown && <div className={arrowClasses}></div>}
-            </div>
-          </div>}
+            <div className={selectedFlagClasses}>{renderStringAsFlag}</div>
+            :
+            <div
+              onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
+              className={selectedFlagClasses}
+              title={selectedCountry ? `${selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
+              tabIndex={disableDropdown ? '-1' : '0'}
+              role='button'
+              aria-haspopup="listbox"
+              aria-expanded={showDropdown ? true : undefined}
+            >
+              <div className={inputFlagClasses}>
+                {!disableDropdown && <div className={arrowClasses}></div>}
+              </div>
+            </div>}
 
-          {showDropdown && this.getCountryDropdownList()}
+          {showDropdown && this.showDropdown()}
         </div>
       </div>
     );

--- a/test/dev:js/demo.js
+++ b/test/dev:js/demo.js
@@ -64,6 +64,12 @@ class Demo extends React.Component {
           />
         </div>
 
+        <div>
+          <br/><br/>
+          <p>Render dropdown in container</p>
+          <PhoneInput dropdownContainerId={'root'} dropdownContainerStyle={{ 'z-index': '10000', 'font-weight': 600 }}/>
+        </div>
+
         <div style={{display: 'inline-block', marginLeft: '40px'}}>
           <p>Auto country detect by value</p>
           <PhoneInput


### PR DESCRIPTION
I have added dropdownContainerId prop to allow render flags select dropdown into custom node. It is vital in my project, because component is used in modal and rendering right dropdown below input doesn't look well. So I think it could be useful - some alternative components have this feature.

Except that there are two optional props: dropdownContainerClass and dropdownContainerStyle for styling. See readme for details.

Thanks!