### PR TITLE
fix(a11y): dom element marked with role="button" expects an aria-labe…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -810,6 +810,7 @@ class PhoneInput extends React.Component {
         <li
           ref={el => this[`flag_no_${index}`] = el}
           key={`flag_no_${index}`}
+          id={`flag-${country.iso2}`}
           data-flag-key={`flag_no_${index}`}
           className={itemClasses}
           data-dial-code='1'
@@ -969,11 +970,18 @@ class PhoneInput extends React.Component {
           <div
             onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
             className={selectedFlagClasses}
-            title={selectedCountry ? `${selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
+
             tabIndex={disableDropdown ? '-1' : '0'}
             role='button'
             aria-haspopup="listbox"
             aria-expanded={showDropdown ? true : undefined}
+            {
+              ...selectedCountry && showDropdown ?
+              { "aria-labelledby": `flag-${selectedCountry.iso2}` } :
+              { "aria-label": selectedCountry ?
+                `${selectedCountry.name}: + ${selectedCountry.dialCode}` :
+                this.props.placeholder }
+            }
           >
             <div className={inputFlagClasses}>
               {!disableDropdown && <div className={arrowClasses}></div>}


### PR DESCRIPTION
Hello, I'm using pa11y-ci for a11y CI. In the process stumble upon a warning : 

```
Errors in file:///Users/mfo/dev/monstage/tmp/w3c/new_user_session_path.html:

 • This element has role of "button" but does not have a name available to an accessibility API. Valid names are: element content, aria-label undefined, aria-labelledby undefined.

   (#new_user > div:nth-child(5) > div > div > div:nth-child(3) > div)

   <div class="selected-flag" title="France: + 33" tabindex="0" role="button" aria-haspopup="listbox"><div class="flag fr"><div class...</div>
```
saying that, pa11y-ci recommend using an aria-label (generic name) or aria-labelledby (points to a dom element describing the label).
so here is a fix for two cases:
1. using the default placeholder as an aria-label when no country is selected
2. using the iso2 as an Id attribute for the listItem of thelistbox.

