### PR TITLE
Add disableAreaCodesDropdown prop to hide area code items in dropdown menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ import es from "react-phone-input-2/lang/es.json";
 
 #### Flexible mask
 
-If `enableAreaCodeStretch` is added, the part of the mask with the area code will not stretch to length of the respective section of phone mask.
+If `enableAreaCodeStretch` is added, the part of the mask with the area code will stretch to the length of the respective section of phone mask.
 Example: `+61 (2), +61 (02)`
 
 ### Custom masks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # React-Phone-Input-2
-
 Highly customizable phone input component with auto formatting.
 
 [![npm version](https://img.shields.io/npm/v/react-phone-input-2.svg?style=flat)](https://www.npmjs.com/package/react-phone-input-2)
@@ -10,24 +9,21 @@ Highly customizable phone input component with auto formatting.
 ![animation](https://media.giphy.com/media/xiORAWnqoTJDsH0UOI/giphy.gif)
 
 ## Installation
-
 ```shell-script
 npm install react-phone-input-2 --save
 ```
 
 ## Usage
-
 ```jsx
-import PhoneInput from "react-phone-input-2";
-import "react-phone-input-2/lib/style.css";
+import PhoneInput from 'react-phone-input-2'
+import 'react-phone-input-2/lib/style.css'
 
 <PhoneInput
-  country={"us"}
+  country={'us'}
   value={this.state.phone}
-  onChange={(phone) => this.setState({ phone })}
-/>;
+  onChange={phone => this.setState({ phone })}
+/>
 ```
-
 **available styles** - style • high-res • material • bootstrap • semantic-ui • plain
 
 #### [Demo 1 (UI)](https://bl00mber.github.io/react-phone-input-2.html) - [Demo 2 (CSS)](https://bl00mber.github.io/react-phone-input-2-css.html)
@@ -35,7 +31,6 @@ import "react-phone-input-2/lib/style.css";
 ![screenshot](https://raw.githubusercontent.com/bl00mber/react-phone-input-2/master/test/screenshot.png)
 
 ## Options
-
 <table>
   <tr>
     <th> Name </th>
@@ -148,15 +143,14 @@ import "react-phone-input-2/lib/style.css";
 ```jsx
 <PhoneInput
   inputProps={{
-    name: "phone",
+    name: 'phone',
     required: true,
-    autoFocus: true,
+    autoFocus: true
   }}
 />
 ```
 
 ### Contents
-
 - [Style](#style)
 - [Events](#events)
 - [Regions](#regions)
@@ -174,7 +168,6 @@ import "react-phone-input-2/lib/style.css";
 - [Support](https://www.paypal.me/bloomber/20)
 
 ### Style
-
 <table>
   <tr>
     <td> containerClass </td>
@@ -230,7 +223,6 @@ import "react-phone-input-2/lib/style.css";
 </table>
 
 ### Events
-
 <table>
   <tr>
     <td> onChange </td>
@@ -264,7 +256,6 @@ Country data object not returns from onKeyDown event
 </table>
 
 ### Regions
-
 <table>
   <tr>
     <th> Name </th>
@@ -306,52 +297,48 @@ Country data object not returns from onKeyDown event
 ```
 
 ### Predefined localization
-
 `es` Spanish, `de` Deutsch, `ru` Russian, `fr` French<br/>
 `jp` Japanese, `cn` Chinese, `pt` Portuguese, `it` Italian<br/>
 `ir` Iranian, `ar` Arabic, `tr` Turkish, `id` Indonesian
 
 ```jsx
-import es from "react-phone-input-2/lang/es.json";
+import es from 'react-phone-input-2/lang/es.json'
 
-<PhoneInput localization={es} />;
+<PhoneInput
+  localization={es}
+/>
 ```
 
 ### Local area codes
-
 ```jsx
 <PhoneInput
   enableAreaCodes={true}
-  enableAreaCodes={["us", "ca"]}
+  enableAreaCodes={['us', 'ca']}
   enableAreaCodeStretch
 />
 ```
 
 #### Flexible mask
-
 If `enableAreaCodeStretch` is added, the part of the mask with the area code will stretch to the length of the respective section of phone mask.
 Example: `+61 (2), +61 (02)`
 
 ### Custom masks
-
 ```jsx
 <PhoneInput
-  onlyCountries={["fr", "at"]}
-  masks={{ fr: "(...) ..-..-..", at: "(....) ...-...." }}
+  onlyCountries={['fr', 'at']}
+  masks={{fr: '(...) ..-..-..', at: '(....) ...-....'}}
 />
 ```
 
 ### Custom area codes
-
 ```jsx
 <PhoneInput
-  onlyCountries={["gr", "fr", "us"]}
-  areaCodes={{ gr: ["2694", "2647"], fr: ["369", "463"], us: ["300"] }}
+  onlyCountries={['gr', 'fr', 'us']}
+  areaCodes={{gr: ['2694', '2647'], fr: ['369', '463'], us: ['300']}}
 />
 ```
 
 ### Other props
-
 <table>
   <tr>
     <td> defaultMask </td>
@@ -425,7 +412,6 @@ Example: `+61 (2), +61 (02)`
 </table>
 
 ### Custom localization
-
 ```jsx
 <PhoneInput
   onlyCountries={['de', 'es']}
@@ -439,18 +425,15 @@ Example: `+61 (2), +61 (02)`
 ```
 
 ### Preserve countries order
-
 ```jsx
 <PhoneInput
-  onlyCountries={["fr", "at"]}
-  preserveOrder={["onlyCountries", "preferredCountries"]}
+  onlyCountries={['fr', 'at']}
+  preserveOrder={['onlyCountries', 'preferredCountries']}
 />
 ```
 
 ## Guides
-
 ### Phone without dialCode
-
 ```jsx
 handleOnChange(value, data, event, formattedValue) {
   this.setState({ rawPhone: value.slice(data.dialCode.length) })
@@ -458,14 +441,13 @@ handleOnChange(value, data, event, formattedValue) {
 ```
 
 ### Check validity of the phone number
-
 `isValid(value, country, countries, hiddenAreaCodes)`
 
 ```jsx
 <PhoneInput
   isValid={(value, country) => {
     if (value.match(/12345/)) {
-      return "Invalid value: " + value + ", " + country.name;
+      return 'Invalid value: '+value+', '+country.name;
     } else if (value.match(/1234/)) {
       return false;
     } else {
@@ -476,38 +458,31 @@ handleOnChange(value, data, event, formattedValue) {
 ```
 
 ```jsx
-import startsWith from "lodash.startswith";
+import startsWith from 'lodash.startswith';
 
 <PhoneInput
   isValid={(inputNumber, country, countries) => {
     return countries.some((country) => {
-      return (
-        startsWith(inputNumber, country.dialCode) ||
-        startsWith(country.dialCode, inputNumber)
-      );
+      return startsWith(inputNumber, country.dialCode) || startsWith(country.dialCode, inputNumber);
     });
   }}
-/>;
+/>
 ```
 
 ### Clear country
-
 To clear `country`, pass `null` as `value`.
 
 ### CDN
-
 ```html
 <script src="https://unpkg.com/react-phone-input-2@2.x/dist/lib.js"></script>
 ```
 
 ## Contributing
-
 - Code style changes not allowed
 - Do not create issues about incorrect or missing country masks (of already present countries) or absent area codes (they will be closed). Only create issues if the subject is an actual mechanism that is not present in the component. Otherwise create a PR with a link that proves the correctness of your newly suggested mask or list of area codes
 - Do not send new languages
 
 ## License
-
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bl00mber/react-phone-input-2/blob/master/LICENSE)
 
 Based on [react-phone-input](https://github.com/razagill/react-phone-input)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # React-Phone-Input-2
+
 Highly customizable phone input component with auto formatting.
 
 [![npm version](https://img.shields.io/npm/v/react-phone-input-2.svg?style=flat)](https://www.npmjs.com/package/react-phone-input-2)
@@ -9,21 +10,24 @@ Highly customizable phone input component with auto formatting.
 ![animation](https://media.giphy.com/media/xiORAWnqoTJDsH0UOI/giphy.gif)
 
 ## Installation
+
 ```shell-script
 npm install react-phone-input-2 --save
 ```
 
 ## Usage
+
 ```jsx
-import PhoneInput from 'react-phone-input-2'
-import 'react-phone-input-2/lib/style.css'
+import PhoneInput from "react-phone-input-2";
+import "react-phone-input-2/lib/style.css";
 
 <PhoneInput
-  country={'us'}
+  country={"us"}
   value={this.state.phone}
-  onChange={phone => this.setState({ phone })}
-/>
+  onChange={(phone) => this.setState({ phone })}
+/>;
 ```
+
 **available styles** - style • high-res • material • bootstrap • semantic-ui • plain
 
 #### [Demo 1 (UI)](https://bl00mber.github.io/react-phone-input-2.html) - [Demo 2 (CSS)](https://bl00mber.github.io/react-phone-input-2-css.html)
@@ -31,6 +35,7 @@ import 'react-phone-input-2/lib/style.css'
 ![screenshot](https://raw.githubusercontent.com/bl00mber/react-phone-input-2/master/test/screenshot.png)
 
 ## Options
+
 <table>
   <tr>
     <th> Name </th>
@@ -143,14 +148,15 @@ import 'react-phone-input-2/lib/style.css'
 ```jsx
 <PhoneInput
   inputProps={{
-    name: 'phone',
+    name: "phone",
     required: true,
-    autoFocus: true
+    autoFocus: true,
   }}
 />
 ```
 
 ### Contents
+
 - [Style](#style)
 - [Events](#events)
 - [Regions](#regions)
@@ -168,6 +174,7 @@ import 'react-phone-input-2/lib/style.css'
 - [Support](https://www.paypal.me/bloomber/20)
 
 ### Style
+
 <table>
   <tr>
     <td> containerClass </td>
@@ -223,6 +230,7 @@ import 'react-phone-input-2/lib/style.css'
 </table>
 
 ### Events
+
 <table>
   <tr>
     <td> onChange </td>
@@ -256,6 +264,7 @@ Country data object not returns from onKeyDown event
 </table>
 
 ### Regions
+
 <table>
   <tr>
     <th> Name </th>
@@ -297,48 +306,52 @@ Country data object not returns from onKeyDown event
 ```
 
 ### Predefined localization
+
 `es` Spanish, `de` Deutsch, `ru` Russian, `fr` French<br/>
 `jp` Japanese, `cn` Chinese, `pt` Portuguese, `it` Italian<br/>
 `ir` Iranian, `ar` Arabic, `tr` Turkish, `id` Indonesian
 
 ```jsx
-import es from 'react-phone-input-2/lang/es.json'
+import es from "react-phone-input-2/lang/es.json";
 
-<PhoneInput
-  localization={es}
-/>
+<PhoneInput localization={es} />;
 ```
 
 ### Local area codes
+
 ```jsx
 <PhoneInput
   enableAreaCodes={true}
-  enableAreaCodes={['us', 'ca']}
+  enableAreaCodes={["us", "ca"]}
   enableAreaCodeStretch
 />
 ```
 
 #### Flexible mask
+
 If `enableAreaCodeStretch` is added, the part of the mask with the area code will not stretch to length of the respective section of phone mask.
 Example: `+61 (2), +61 (02)`
 
 ### Custom masks
+
 ```jsx
 <PhoneInput
-  onlyCountries={['fr', 'at']}
-  masks={{fr: '(...) ..-..-..', at: '(....) ...-....'}}
+  onlyCountries={["fr", "at"]}
+  masks={{ fr: "(...) ..-..-..", at: "(....) ...-...." }}
 />
 ```
 
 ### Custom area codes
+
 ```jsx
 <PhoneInput
-  onlyCountries={['gr', 'fr', 'us']}
-  areaCodes={{gr: ['2694', '2647'], fr: ['369', '463'], us: ['300']}}
+  onlyCountries={["gr", "fr", "us"]}
+  areaCodes={{ gr: ["2694", "2647"], fr: ["369", "463"], us: ["300"] }}
 />
 ```
 
 ### Other props
+
 <table>
   <tr>
     <td> defaultMask </td>
@@ -405,9 +418,14 @@ Example: `+61 (2), +61 (02)`
     <td> disableCountryGuess </td>
     <td> false </td>
   </tr>
+  <tr>
+    <td> disableAreaCodesDropdown </td>
+    <td> false </td>
+  </tr>
 </table>
 
 ### Custom localization
+
 ```jsx
 <PhoneInput
   onlyCountries={['de', 'es']}
@@ -421,15 +439,18 @@ Example: `+61 (2), +61 (02)`
 ```
 
 ### Preserve countries order
+
 ```jsx
 <PhoneInput
-  onlyCountries={['fr', 'at']}
-  preserveOrder={['onlyCountries', 'preferredCountries']}
+  onlyCountries={["fr", "at"]}
+  preserveOrder={["onlyCountries", "preferredCountries"]}
 />
 ```
 
 ## Guides
+
 ### Phone without dialCode
+
 ```jsx
 handleOnChange(value, data, event, formattedValue) {
   this.setState({ rawPhone: value.slice(data.dialCode.length) })
@@ -437,13 +458,14 @@ handleOnChange(value, data, event, formattedValue) {
 ```
 
 ### Check validity of the phone number
+
 `isValid(value, country, countries, hiddenAreaCodes)`
 
 ```jsx
 <PhoneInput
   isValid={(value, country) => {
     if (value.match(/12345/)) {
-      return 'Invalid value: '+value+', '+country.name;
+      return "Invalid value: " + value + ", " + country.name;
     } else if (value.match(/1234/)) {
       return false;
     } else {
@@ -454,31 +476,38 @@ handleOnChange(value, data, event, formattedValue) {
 ```
 
 ```jsx
-import startsWith from 'lodash.startswith';
+import startsWith from "lodash.startswith";
 
 <PhoneInput
   isValid={(inputNumber, country, countries) => {
     return countries.some((country) => {
-      return startsWith(inputNumber, country.dialCode) || startsWith(country.dialCode, inputNumber);
+      return (
+        startsWith(inputNumber, country.dialCode) ||
+        startsWith(country.dialCode, inputNumber)
+      );
     });
   }}
-/>
+/>;
 ```
 
 ### Clear country
+
 To clear `country`, pass `null` as `value`.
 
 ### CDN
+
 ```html
 <script src="https://unpkg.com/react-phone-input-2@2.x/dist/lib.js"></script>
 ```
 
 ## Contributing
+
 - Code style changes not allowed
 - Do not create issues about incorrect or missing country masks (of already present countries) or absent area codes (they will be closed). Only create issues if the subject is an actual mechanism that is not present in the component. Otherwise create a PR with a link that proves the correctness of your newly suggested mask or list of area codes
 - Do not send new languages
 
 ## License
+
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bl00mber/react-phone-input-2/blob/master/LICENSE)
 
 Based on [react-phone-input](https://github.com/razagill/react-phone-input)

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,7 @@ declare module "react-phone-input-2" {
     specialLabel?: string;
     disableInitialCountryGuess?: boolean;
     disableCountryGuess?: boolean;
+    disableAreaCodesDropdown?: boolean,
   }
   const PhoneInput: React.FC<PhoneInputProps>;
   export default PhoneInput;

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ class PhoneInput extends React.Component {
     disableSearchIcon: PropTypes.bool,
     disableInitialCountryGuess: PropTypes.bool,
     disableCountryGuess: PropTypes.bool,
+    disableAreaCodesDropdown: PropTypes.bool,
 
     regions: PropTypes.oneOfType([
       PropTypes.string,
@@ -136,6 +137,7 @@ class PhoneInput extends React.Component {
     disableSearchIcon: false,
     disableInitialCountryGuess: false,
     disableCountryGuess: false,
+    disableAreaCodesDropdown: false,
 
     regions: '',
 
@@ -762,7 +764,7 @@ class PhoneInput extends React.Component {
 
   getSearchFilteredCountries = () => {
     const { preferredCountries, onlyCountries, searchValue } = this.state
-    const { enableSearch } = this.props
+    const { enableSearch, disableAreaCodesDropdown } = this.props
     const allCountries = preferredCountries.concat(onlyCountries);
     const sanitizedSearchValue = searchValue.trim().toLowerCase();
     if (enableSearch && sanitizedSearchValue) {
@@ -784,7 +786,13 @@ class PhoneInput extends React.Component {
         return [...new Set([].concat(iso2countries, searchedCountries))]
       }
     } else {
-      return allCountries
+      const filteredCountries = allCountries.filter((country) => {
+        if (country.isAreaCode) {
+          return false;
+        }
+        return true;
+      })
+      return disableAreaCodesDropdown ? filteredCountries : allCountries
     }
   }
 


### PR DESCRIPTION
This enables us to show only the main countries in the dropdown menu (and avoid a huge list of repeated countries), but still use the extended functionality of mask and format for area codes (in countries that have variable area codes, such as Argentina, that has both 2 and 3 digit codes).