### PR TITLE
feat: Add Faroe Islands to county list

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -409,6 +409,12 @@ const rawCountries = [
     '251'
   ],
   [
+    'Faroe Islands',
+    ['europe'],
+    'fo',
+    '298'
+  ],
+  [
     'Fiji',
     ['oceania'],
     'fj',


### PR DESCRIPTION
country code and phone number verified https://laendercode.net/en/country/fo
not part of the EU according to https://en.wikipedia.org/wiki/Faroe_Islands_and_the_European_Union

Flag is already there:
https://github.com/bl00mber/react-phone-input-2/blob/master/src/style/common/flags.less#L209
https://github.com/bl00mber/react-phone-input-2/blob/master/src/style/common/high-res-flags.less#L88

closes #401 