### PR TITLE
adds onMount prop to hook into componentDidMount and return guessed c…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,11 @@ declare module "react-phone-input-2" {
       countries: object[],
       hiddenAreaCodes: object[],
     ) => boolean | string) | boolean;
+    onMount?(
+      value: string,
+      data: CountryData | {},
+      formattedValue: string
+    ): void;
   }
 
   export interface PhoneInputProps extends PhoneInputEventsProps, Style {

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ class PhoneInput extends React.Component {
     onClick: PropTypes.func,
     onKeyDown: PropTypes.func,
     onEnterKeyPress: PropTypes.func,
+    onMount: PropTypes.func,
     isValid: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.func,
@@ -231,6 +232,9 @@ class PhoneInput extends React.Component {
   componentDidMount() {
     if (document.addEventListener && this.props.enableClickOutside) {
       document.addEventListener('mousedown', this.handleClickOutside);
+    }
+    if(this.props.onMount){
+        this.props.onMount(this.state.formattedNumber.replace(/[^0-9]+/g,''), this.getCountryData(), this.state.formattedNumber)
     }
   }
 


### PR DESCRIPTION
I need to have access to the guessed countryData from the inner component's state at mount time so I can validate if the number matches the country's standards using libphonenumber-js.

A more effective way of fixing my problem would be to extract the guessing logic to a separate class or module and using it after fetching data, but this approach is less impactful and does it for me.