### PR TITLE
Add faroe islands to country list

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -408,6 +408,11 @@ const rawCountries = [
     'et',
     '251'
   ],
+  ['Faroe Islands',
+    ['europe'],
+    'fo',
+    '298'
+  ],
   [
     'Fiji',
     ['oceania'],


### PR DESCRIPTION
The country flag exists in the repository, but the Faroe Islands is missing from the list.