### PR TITLE
Create tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
As there is no tsconfig.json file, IntelliJ IDEs will complain about default imports without having this flag set to true. 
This error is triggered in `index.d.ts` on line 2:
```import React from "react";```

Error:
```TS1259: Module '"[...obusfacted...]/node_modules/@types/react/index"' can only be default-imported using the 'esModuleInterop' flag```