### PR TITLE
Fix "replace is not a function" when value is number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,8 @@ class PhoneInput extends React.Component {
       props.prefix, props.defaultMask, props.alwaysDefaultMask,
     );
 
-    const inputNumber = props.value ? props.value.replace(/\D/g, '') : '';
+    const strInputNumber = typeof props.value === 'number' ? `${props.value}` : props.value
+    const inputNumber = strInputNumber ? strInputNumber.replace(/\D/g, '') : '';
 
     let countryGuess;
     if (props.disableInitialCountryGuess) {


### PR DESCRIPTION
Fixed situation when value is number