### PR TITLE
Add emptyCountryDropdownTitle when there is no country chosen

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ import 'react-phone-input-2/lib/style.css'
   </tr>
 
   <tr>
+    <td> emptyCountryDropdownTitle </td>
+    <td> string </td>
+    <td colspan="2"> fall back dropdown title in the event there is no country chosen </td>
+  </tr>
+
+  <tr>
     <td> inputProps </td>
     <td> object </td>
     <td colspan="2"> props to pass into the input </td>

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ declare module "react-phone-input-2" {
 
     regions?: string | string[];
 
+    emptyCountryDropdownTitle?: string;
     inputProps?: object;
     localization?: object;
     masks?: object;

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ class PhoneInput extends React.Component {
       PropTypes.arrayOf(PropTypes.string)
     ]),
 
+    emptyCountryDropdownTitle: PropTypes.string,
     inputProps: PropTypes.object,
     localization: PropTypes.object,
     masks: PropTypes.object,
@@ -139,6 +140,7 @@ class PhoneInput extends React.Component {
 
     regions: '',
 
+    emptyCountryDropdownTitle: '',
     inputProps: {},
     localization: {},
 
@@ -969,7 +971,7 @@ class PhoneInput extends React.Component {
           <div
             onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
             className={selectedFlagClasses}
-            title={selectedCountry ? `${selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
+            title={selectedCountry ? `${selectedCountry.name}: + ${selectedCountry.dialCode}` : props.emptyCountryDropdownTitle}
             tabIndex={disableDropdown ? '-1' : '0'}
             role='button'
             aria-haspopup="listbox"


### PR DESCRIPTION
We're rendering the react-phone-input-2 component and since the flag dropdown doesn't have a title when there is no country chosen, it's failing our axe checks 
```

"ARIA commands must have an accessible name (aria-command-name)"

Fix any of the following:
  aria-label attribute does not exist or is empty
  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
  Element has an empty title attribute
  Element does not have text that is visible to screen readers

You can find more information on this issue here: 
https://dequeuniversity.com/rules/axe/4.1/aria-command-name?application=axeAPI
    at Object.<anonymous> (/Users/mattcrowder-mbpr16/work/web/patients/src/pages/confirm-new-number/__tests__/confirm-new-number.test.js:75:32)
    at runNextTicks (internal/process/task_queues.js:62:5)
    at listOnTimeout (internal/timers.js:523:9)
    at processTimers (internal/timers.js:497:7)

```

Providing the ability to add a fallback will let us pass this check.