### PR TITLE
Fix: Uncaught TypeError when country is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -553,7 +553,7 @@ class PhoneInput extends React.Component {
       // we don't need to send the whole number to guess the country... only the first 6 characters are enough
       // the guess country function can then use memoization much more effectively since the set of input it
       // gets has drastically reduced
-      if (!this.state.freezeSelection || selectedCountry.dialCode.length > inputNumber.length) {
+      if (!this.state.freezeSelection || selectedCountry.dialCode && selectedCountry.dialCode.length > inputNumber.length) {
         if (this.props.disableCountryGuess) {newSelectedCountry = selectedCountry;}
         else {
           newSelectedCountry = this.guessSelectedCountry(inputNumber.substring(0, 6), country, onlyCountries, hiddenAreaCodes) || selectedCountry;


### PR DESCRIPTION
### Steps to Reproduce
1. Set `value = null` (to clear `country`) when input's empty:
> <PhoneInputComponent
  value={phone.value || null}
/>
2. Change the country on dropdown (to trigger `handleFlagItemClick()`);
3. Clear the inserted countryCode;
4. Try to type in the input again;
### Expected Result:
To be able to insert a new value;
### Actual Result:
Javascript exception `Uncaught TypeError: Cannot read properties of undefined (reading 'length')` on the following condition:
index.js:556:
> if (!_this.state.freezeSelection || `selectedCountry.dialCode.length` > inputNumber.length) {
### Explanation:
The `handleInput()` method works well with the initial `freezeSelection=false` set on Constructor (index.js#225).
But when `handleFlagItemClick()` is called the `freezeSelection` state is set to `true`.
When `freezeSelection` is trully the second condition will be tested (`selectedCountry.dialCode.length > inputNumber.length`) but since we cleared the input `selectedCoutry` will be `0` (the default countryGuess) and an typeError will be raised when it tries to access the object `dialCode` property;