### PR TITLE
#352 Fix caret position on edit not last number group

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -564,6 +564,7 @@ class PhoneInput extends React.Component {
       newSelectedCountry = newSelectedCountry.dialCode ? newSelectedCountry : selectedCountry;
     }
 
+    const oldCaretPosition = e.target.selectionStart;
     let caretPosition = e.target.selectionStart;
     const oldFormattedText = this.state.formattedNumber;
     const diff = formattedNumber.length - oldFormattedText.length;
@@ -581,9 +582,10 @@ class PhoneInput extends React.Component {
 
       if (lastChar == ')') {
         this.numberInputRef.setSelectionRange(formattedNumber.length - 1, formattedNumber.length - 1);
-      }
-      else if (caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
+      } else if (caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
         this.numberInputRef.setSelectionRange(caretPosition, caretPosition);
+      } else if (oldCaretPosition < oldFormattedText.length) {
+        this.numberInputRef.setSelectionRange(oldCaretPosition, oldCaretPosition);
       }
 
       if (onChange) onChange(formattedNumber.replace(/[^0-9]+/g,''), this.getCountryData(), e, formattedNumber);


### PR DESCRIPTION
Fix caret jumping to end when editing not last group of numbers

Before:
![Watch the video](https://user-images.githubusercontent.com/10918687/144443362-3ce49db7-259c-4df4-a43f-c850d2df3a10.mov)

After:
![Watch the video](https://user-images.githubusercontent.com/10918687/144443383-f3eccfdc-0e99-408f-b76a-98896046bb79.mov)
