### PR TITLE
Add type and value checking for localization

### DIFF
--- a/src/CountryData.js
+++ b/src/CountryData.js
@@ -201,12 +201,14 @@ export default class CountryData {
   }
 
   localizeCountries = (countries, localization, preserveOrder) => {
-    for (let i = 0; i < countries.length; i++) {
-      if (localization[countries[i].iso2] !== undefined) {
-        countries[i].localName = localization[countries[i].iso2];
-      }
-      else if (localization[countries[i].name] !== undefined) {
-        countries[i].localName = localization[countries[i].name];
+    if (localization && typeof localization === 'object') {
+      for (let i = 0; i < countries.length; i++) {
+        if (localization[countries[i].iso2] !== undefined) {
+          countries[i].localName = localization[countries[i].iso2];
+        }
+        else if (localization[countries[i].name] !== undefined) {
+          countries[i].localName = localization[countries[i].name];
+        }
       }
     }
     if (!preserveOrder) {


### PR DESCRIPTION
On a project we have an issue: The label for Austria is missed 

<img width="246" alt="image" src="https://user-images.githubusercontent.com/5623316/158034600-02521867-acc6-4de1-9ed7-d4d5d8a71221.png">

Here is a result of my investigation.

```
const countries = [{
  countryCode: "43",
  dialCode: "43",
  format: ".. ... ... ... ... ..",
  iso2: "at",
  name: "Austria",
  priority: 0,
  regions: ['europe', 'eu-union'],
}];

const localization =  ""; // this is our default value from the props, but as I see it might be undefined and I didn't see value and type checking of it

const preserveOrder = false;

const localizeCountries = (countries, localization, preserveOrder) => {
    for (let i = 0; i < countries.length; i++) {
      if (localization[countries[i].iso2] !== undefined) {
        countries[i].localName = localization[countries[i].iso2];
        // In the string above we had that **countries[i].iso2** is **"at"**
        // But if localization has String type then localization["at"] will be equal String.prototype.at()
        // As a result after we will run localizeCountries(countries, "", false) the result will be
        // [{
        //    countryCode: "43",
        //    dialCode: "43",
        //    format: ".. ... ... ... ... ..",
        //    iso2: "at",
        //    **localName: ƒ at(),** // except to have undefined there
        //    name: "Austria",
        //    priority: 0,
        //    regions: ['europe', 'eu-union'],
        //    }]
      }
      else if (localization[countries[i].name] !== undefined) {
        countries[i].localName = localization[countries[i].name];
      }
    }
    if (!preserveOrder) {
      countries.sort(function(a, b){
        if(a.localName < b.localName) { return -1; }
        if(a.localName > b.localName) { return 1; }
        return 0;
      });
    }
    return countries;
  }
```

Since function will return us:

```
const result = [{
    countryCode: "43"
    dialCode: "43"
    format: ".. ... ... ... ... .."
    iso2: "at"
    localName: ƒ at()
    name: "Austria"
    priority: 0
    regions: ['europe', 'eu-union']
}];
```

then in render function we will have: 

```
getDropdownCountryName = (country) => {
    return country.localName || country.name; 
    // Boolean(result[0].localName) is true and we will receive result[0].localName as a result
}
  
result.map((country) => (
    <span className='country-name'>{this.getDropdownCountryName(country)}</span>
))
```

And from the next screenshot you can see that it will be at() in the span tag but it was expected to see "Austria" there
<img width="590" alt="Screenshot 2022-03-15 at 02 17 55" src="https://user-images.githubusercontent.com/5623316/158276681-b7778170-4879-435f-ae09-dcbd82336fee.png">


To solve this issue we just need to check localization value and type.
