### PR TITLE
Make compatible with vite

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ if (TARGET === 'build_js' || TARGET === 'analyze') {
     optimization: {},
     output: {
       library: 'ReactPhoneInput',
-      libraryTarget: 'commonjs2',
+      libraryTarget: 'umd',
       globalObject: 'this'
     },
     externals: [


### PR DESCRIPTION
Hello,

I made these changes to the webpack config to this library.

* Changed library type to UMD.
		This is because the CommonJS2 build is not compatible with vite.js.

Not sure why, but if you build in production-mode the library doesn't work and gives react minification error 130.