### PR TITLE
Add masks for Puerto Rico and Dominican Republic

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -363,7 +363,7 @@ const rawCountries = [
     ['america', 'carribean'],
     'do',
     '1',
-    '',
+    '(...) ...-....',
     2, ['809', '829', '849']
   ],
   [

--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -991,7 +991,7 @@ const rawCountries = [
     ['america', 'carribean'],
     'pr',
     '1',
-    '',
+    '(...) ...-....',
     3, ['787', '939']
   ],
   [


### PR DESCRIPTION
Currently, the validation for Puerto Rico and Dominican Republic fails with false negatives.

You can test by writing or pasting this **valid** phone number `+1 (939) 327-4822` into the input field.

[Ten-Digit-Dialing](https://en.wikipedia.org/wiki/Ten-digit_dialing) is mandatory for both [Puerto Rico](https://en.wikipedia.org/wiki/Telephone_numbers_in_Puerto_Rico) and the [Dominican Republic.](https://en.wikipedia.org/wiki/Area_codes_809,_829,_and_849)

This PR adds format `'(...) ...-....',` to Puerto Rico and Dominican Republic in `rawCountries`, which in turns solves the issue, which has been previously mentioned in #177 