### PR TITLE
add onto country data type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,10 @@ declare module "react-phone-input-2" {
     dialCode: string;
     countryCode: string;
     format: string;
+    iso2?: string;
+    mainCode?: boolean;
+    priority?: number;
+    regions?: string[]
   }
 
   interface Style {
@@ -45,7 +49,7 @@ declare module "react-phone-input-2" {
     onEnterKeyPress?(event: React.KeyboardEvent<HTMLInputElement>): void;
     isValid?: ((
       value: string,
-      country: object,
+      country: CountryData | {},
       countries: object[],
       hiddenAreaCodes: object[],
     ) => boolean | string) | boolean;


### PR DESCRIPTION
- adding optional params onto `CountryData` to be compatible with `country` object in `isValid`
- this is to fix typescript error `Property 'format' does not exist on type 'object'`  when trying to access keys on `country` object in `isValid` callback
<img width="842" alt="Screen Shot 2022-07-19 at 5 52 39 PM" src="https://user-images.githubusercontent.com/60310001/179872435-cc4a1c7f-e994-400c-bc13-0a4a5e40f207.png">

