### PR TITLE
Allow relative width for the country dropdown list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -986,7 +986,7 @@ class PhoneInput extends React.Component {
         <div
           className={flagViewClasses}
           style={this.props.buttonStyle}
-          ref={el => this.dropdownContainerRef = el}
+          
         >
           {renderStringAsFlag ?
           <div className={selectedFlagClasses}>{renderStringAsFlag}</div>
@@ -1005,8 +1005,10 @@ class PhoneInput extends React.Component {
             </div>
           </div>}
         </div>
-        
-        {showDropdown && this.getCountryDropdownList()}
+
+        <div ref={el => this.dropdownContainerRef = el}>
+          {showDropdown && this.getCountryDropdownList()}
+        </div>
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1006,9 +1006,11 @@ class PhoneInput extends React.Component {
           </div>}
         </div>
 
-        <div ref={el => this.dropdownContainerRef = el}>
-          {showDropdown && this.getCountryDropdownList()}
-        </div>
+        {showDropdown && (
+          <div ref={(el) => (this.dropdownContainerRef = el)}>
+            {this.getCountryDropdownList()}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1004,9 +1004,9 @@ class PhoneInput extends React.Component {
               {!disableDropdown && <div className={arrowClasses}></div>}
             </div>
           </div>}
-
-          {showDropdown && this.getCountryDropdownList()}
         </div>
+        
+        {showDropdown && this.getCountryDropdownList()}
       </div>
     );
   }


### PR DESCRIPTION
Hello,

I made these changes to allow developers to override the dropdown's width with relative lengths like %. Default lengths remain 300px

For example

```js
<div>
  <PhoneInput
    inputStyle={{ width: "100%" }}
    dropdownStyle={{ width: "100%" }}
  />
</div>
```

I'm not sure if moving the country list outside the flag-dropdown div does break any featrue i'm unaware of.

fix #308 