### PR TITLE
Added correct formatting for Ivory Coast phone number

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -271,7 +271,7 @@ const rawCountries = [
     ['america', 'south-america'],
     'co',
     '57',
-    '... ... ....'
+    '.. .. .. .. ..'
   ],
   [
     'Comoros',

--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -303,7 +303,7 @@ const rawCountries = [
     ['africa'],
     'ci',
     '225',
-    '.. .. .. ..'
+    '.. .. ... ...'
   ],
   [
     'Croatia',


### PR DESCRIPTION
Hello,
I noticed an issue in your library: the mask for Ivory Coast is incorrect.
Phone number either 8 or 10 digits in the following format: `xx xx xx xx xx`

https://en.wikipedia.org/wiki/Telephone_numbers_in_Ivory_Coast

I set the mask to `xx xx xx xx xx` so that both 8 and 10 digits numbers are readable.

