### PR TITLE
✅ Adds support for passing "data-id" down to input to allow for easier testing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,6 +106,7 @@ declare module "react-phone-input-2" {
     specialLabel?: string;
     disableInitialCountryGuess?: boolean;
     disableCountryGuess?: boolean;
+    "data-id"?: string;
   }
   const PhoneInput: React.FC<PhoneInputProps>;
   export default PhoneInput;

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ class PhoneInput extends React.Component {
     ]),
     defaultErrorMessage: PropTypes.string,
     specialLabel: PropTypes.string,
+    "data-id": PropTypes.string,
   }
 
   static defaultProps = {
@@ -167,6 +168,8 @@ class PhoneInput extends React.Component {
     defaultErrorMessage: '',
     specialLabel: 'Phone',
 
+    "data-id": '',
+
     onEnterKeyPress: null, // null or function
 
     keys: {
@@ -208,10 +211,10 @@ class PhoneInput extends React.Component {
 
     let formattedNumber;
     formattedNumber = (inputNumber === '' && countryGuess === 0) ? '' :
-    this.formatNumber(
-      (props.disableCountryCode ? '' : dialCode) + inputNumber,
-      countryGuess.name ? countryGuess : undefined
-    );
+      this.formatNumber(
+        (props.disableCountryCode ? '' : dialCode) + inputNumber,
+        countryGuess.name ? countryGuess : undefined
+      );
 
     const highlightCountryIndex = onlyCountries.findIndex(o => o == countryGuess);
 
@@ -236,8 +239,8 @@ class PhoneInput extends React.Component {
     if (document.addEventListener && this.props.enableClickOutside) {
       document.addEventListener('mousedown', this.handleClickOutside);
     }
-    if(this.props.onMount){
-        this.props.onMount(this.state.formattedNumber.replace(/[^0-9]+/g,''), this.getCountryData(), this.state.formattedNumber)
+    if (this.props.onMount) {
+      this.props.onMount(this.state.formattedNumber.replace(/[^0-9]+/g, ''), this.getCountryData(), this.state.formattedNumber)
     }
   }
 
@@ -300,7 +303,7 @@ class PhoneInput extends React.Component {
         }
       }
       return selectedCountry;
-    }, {dialCode: '', priority: 10001}, this);
+    }, { dialCode: '', priority: 10001 }, this);
 
     if (!bestGuess.name) return secondBestGuess;
     return bestGuess;
@@ -340,7 +343,7 @@ class PhoneInput extends React.Component {
       this.setState({ formattedNumber });
     }
     else {
-      if (this.props.disableCountryGuess) {newSelectedCountry = selectedCountry;}
+      if (this.props.disableCountryGuess) { newSelectedCountry = selectedCountry; }
       else {
         newSelectedCountry = this.guessSelectedCountry(inputNumber.substring(0, 6), country, onlyCountries, hiddenAreaCodes) || selectedCountry;
       }
@@ -426,7 +429,7 @@ class PhoneInput extends React.Component {
     // for all strings with length less than 3, just return it (1, 2 etc.)
     // also return the same text if the selected country has no fixed format
     if ((text && text.length < 2) || !pattern || !autoFormat) {
-      return disableCountryCode ? text : this.props.prefix+text;
+      return disableCountryCode ? text : this.props.prefix + text;
     }
 
     const formattedObject = reduce(pattern, (acc, character) => {
@@ -441,7 +444,7 @@ class PhoneInput extends React.Component {
         };
       }
 
-      const [ head, ...tail ] = acc.remainingText;
+      const [head, ...tail] = acc.remainingText;
 
       return {
         formattedText: acc.formattedText + head,
@@ -470,7 +473,7 @@ class PhoneInput extends React.Component {
     if (document.activeElement !== input) return;
     input.focus();
     let len = input.value.length;
-    if (input.value.charAt(len-1)=== ')') len = len-1;
+    if (input.value.charAt(len - 1) === ')') len = len - 1;
     input.setSelectionRange(len, len);
   }
 
@@ -523,7 +526,7 @@ class PhoneInput extends React.Component {
         this.state.onlyCountries.find(o => o.iso2 === newSelectedCountry.iso2 && o.mainCode).dialCode :
         newSelectedCountry.dialCode;
 
-      const updatedInput = prefix+mainCode;
+      const updatedInput = prefix + mainCode;
       if (value.slice(0, updatedInput.length) !== updatedInput) return;
     }
 
@@ -564,7 +567,7 @@ class PhoneInput extends React.Component {
       // the guess country function can then use memoization much more effectively since the set of input it
       // gets has drastically reduced
       if (!this.state.freezeSelection || (!!selectedCountry && selectedCountry.dialCode.length > inputNumber.length)) {
-        if (this.props.disableCountryGuess) {newSelectedCountry = selectedCountry;}
+        if (this.props.disableCountryGuess) { newSelectedCountry = selectedCountry; }
         else {
           newSelectedCountry = this.guessSelectedCountry(inputNumber.substring(0, 6), country, onlyCountries, hiddenAreaCodes) || selectedCountry;
         }
@@ -598,7 +601,7 @@ class PhoneInput extends React.Component {
         this.numberInputRef.setSelectionRange(oldCaretPosition, oldCaretPosition);
       }
 
-      if (onChange) onChange(formattedNumber.replace(/[^0-9]+/g,''), this.getCountryData(), e, formattedNumber);
+      if (onChange) onChange(formattedNumber.replace(/[^0-9]+/g, ''), this.getCountryData(), e, formattedNumber);
     });
   }
 
@@ -629,7 +632,7 @@ class PhoneInput extends React.Component {
       searchValue: ''
     }, () => {
       this.cursorToEnd();
-      if (this.props.onChange) this.props.onChange(formattedNumber.replace(/[^0-9]+/g,''), this.getCountryData(), e, formattedNumber);
+      if (this.props.onChange) this.props.onChange(formattedNumber.replace(/[^0-9]+/g, ''), this.getCountryData(), e, formattedNumber);
     });
   }
 
@@ -639,7 +642,7 @@ class PhoneInput extends React.Component {
       if (this.numberInputRef.value === this.props.prefix && this.state.selectedCountry && !this.props.disableCountryCode) {
         this.setState({
           formattedNumber: this.props.prefix + this.state.selectedCountry.dialCode
-        }, () => {this.props.jumpCursorToEnd && setTimeout(this.cursorToEnd, 0)});
+        }, () => { this.props.jumpCursorToEnd && setTimeout(this.cursorToEnd, 0) });
       }
     }
 
@@ -656,7 +659,7 @@ class PhoneInput extends React.Component {
 
   handleInputCopy = (e) => {
     if (!this.props.copyNumbersOnly) return;
-    const text = window.getSelection().toString().replace(/[^0-9]+/g,'');
+    const text = window.getSelection().toString().replace(/[^0-9]+/g, '');
     e.clipboardData.setData('text/plain', text);
     e.preventDefault();
   }
@@ -679,7 +682,7 @@ class PhoneInput extends React.Component {
 
     this.scrollTo(this.getElement(probableCandidateIndex), true);
 
-    this.setState({queryString: '', highlightCountryIndex: probableCandidateIndex});
+    this.setState({ queryString: '', highlightCountryIndex: probableCandidateIndex });
   }
 
   handleKeydown = (e) => {
@@ -693,10 +696,10 @@ class PhoneInput extends React.Component {
     if (className.includes('search-box')) {
       if (e.which !== keys.UP && e.which !== keys.DOWN && e.which !== keys.ENTER) {
         if (e.which === keys.ESC && e.target.value === '') {
-         // do nothing // if search field is empty, pass event (close dropdown)
-       } else {
-         return; // don't process other events coming from the search field
-       }
+          // do nothing // if search field is empty, pass event (close dropdown)
+        } else {
+          return; // don't process other events coming from the search field
+        }
       }
     }
 
@@ -782,12 +785,12 @@ class PhoneInput extends React.Component {
     const { preferredCountries, onlyCountries, searchValue } = this.state
     const { enableSearch } = this.props
     const allCountries = this.concatPreferredCountries(preferredCountries, onlyCountries);
-    const sanitizedSearchValue = searchValue.trim().toLowerCase().replace('+','');
+    const sanitizedSearchValue = searchValue.trim().toLowerCase().replace('+', '');
     if (enableSearch && sanitizedSearchValue) {
       // [...new Set()] to get rid of duplicates
       // firstly search by iso2 code
       if (/^\d+$/.test(sanitizedSearchValue)) { // contains digits only
-         // values wrapped in ${} to prevent undefined
+        // values wrapped in ${} to prevent undefined
         return allCountries.filter(({ dialCode }) =>
           [`${dialCode}`].some(field => field.toLowerCase().includes(sanitizedSearchValue)))
       } else {
@@ -835,19 +838,19 @@ class PhoneInput extends React.Component {
           data-country-code={country.iso2}
           onClick={(e) => this.handleFlagItemClick(country, e)}
           role='option'
-          {... highlight ? { "aria-selected": true } : {}}
+          {...highlight ? { "aria-selected": true } : {}}
         >
-          <div className={inputFlagClasses}/>
+          <div className={inputFlagClasses} />
           <span className='country-name'>{this.getDropdownCountryName(country)}</span>
-          <span className='dial-code'>{country.format ? this.formatNumber(country.dialCode, country) : (prefix+country.dialCode)}</span>
+          <span className='dial-code'>{country.format ? this.formatNumber(country.dialCode, country) : (prefix + country.dialCode)}</span>
         </li>
       );
     });
 
-    const dashedLi = (<li key={'dashes'} className='divider'/>);
+    const dashedLi = (<li key={'dashes'} className='divider' />);
     // let's insert a dashed line in between preffered countries and the rest
     (preferredCountries.length > 0) && (!enableSearch || enableSearch && !searchValue.trim()) &&
-    countryDropdownList.splice(preferredCountries.length, 0, dashedLi);
+      countryDropdownList.splice(preferredCountries.length, 0, dashedLi);
 
     const dropDownClasses = classNames({
       'country-list': true,
@@ -932,7 +935,7 @@ class PhoneInput extends React.Component {
       [this.props.containerClass]: true,
       'react-tel-input': true,
     });
-    const arrowClasses = classNames({'arrow': true, 'up': showDropdown});
+    const arrowClasses = classNames({ 'arrow': true, 'up': showDropdown });
     const inputClasses = classNames({
       'form-control': true,
       'invalid-number': !isValidValue,
@@ -971,6 +974,7 @@ class PhoneInput extends React.Component {
           onKeyDown={this.handleInputKeyDown}
           placeholder={this.props.placeholder}
           disabled={this.props.disabled}
+          data-id={this.props["data-id"]}
           type='tel'
           {...this.props.inputProps}
           ref={el => {
@@ -989,21 +993,21 @@ class PhoneInput extends React.Component {
           ref={el => this.dropdownContainerRef = el}
         >
           {renderStringAsFlag ?
-          <div className={selectedFlagClasses}>{renderStringAsFlag}</div>
-          :
-          <div
-            onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
-            className={selectedFlagClasses}
-            title={selectedCountry ? `${selectedCountry.localName || selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
-            tabIndex={disableDropdown ? '-1' : '0'}
-            role='button'
-            aria-haspopup="listbox"
-            aria-expanded={showDropdown ? true : undefined}
-          >
-            <div className={inputFlagClasses}>
-              {!disableDropdown && <div className={arrowClasses}></div>}
-            </div>
-          </div>}
+            <div className={selectedFlagClasses}>{renderStringAsFlag}</div>
+            :
+            <div
+              onClick={disableDropdown ? undefined : this.handleFlagDropdownClick}
+              className={selectedFlagClasses}
+              title={selectedCountry ? `${selectedCountry.localName || selectedCountry.name}: + ${selectedCountry.dialCode}` : ''}
+              tabIndex={disableDropdown ? '-1' : '0'}
+              role='button'
+              aria-haspopup="listbox"
+              aria-expanded={showDropdown ? true : undefined}
+            >
+              <div className={inputFlagClasses}>
+                {!disableDropdown && <div className={arrowClasses}></div>}
+              </div>
+            </div>}
 
           {showDropdown && this.getCountryDropdownList()}
         </div>

--- a/test/ReactPhoneInput.test.js
+++ b/test/ReactPhoneInput.test.js
@@ -72,8 +72,8 @@ describe('<PhoneInput /> event handlers', () => {
         onChange={mockFn}
       />)
 
-    fireEvent.change(phoneInput.querySelector('.form-control'), {target: {value: '12345'}})
-    expect(mockFn).toHaveBeenCalledWith('12345', {name: 'United States', dialCode: '1', 'format': '+. (...) ...-....', countryCode: 'us'}, expect.any(Object), '+1 (234) 5')
+    fireEvent.change(phoneInput.querySelector('.form-control'), { target: { value: '12345' } })
+    expect(mockFn).toHaveBeenCalledWith('12345', { name: 'United States', dialCode: '1', 'format': '+. (...) ...-....', countryCode: 'us' }, expect.any(Object), '+1 (234) 5')
   })
 })
 
@@ -82,7 +82,7 @@ describe('<PhoneInput /> other props', () => {
   test('pass inputProps into the input', () => {
     const { container: phoneInput } = render(
       <PhoneInput
-        inputProps={{name: 'phone'}}
+        inputProps={{ name: 'phone' }}
       />)
 
     expect(phoneInput.querySelector('.form-control').name).toBe('phone')
@@ -105,7 +105,7 @@ describe('<PhoneInput /> other props', () => {
     const { container: phoneInput } = render(
       <PhoneInput
         onlyCountries={['de', 'es']}
-        localization={{'Germany': 'Deutschland', 'Spain': 'España'}}
+        localization={{ 'Germany': 'Deutschland', 'Spain': 'España' }}
       />)
 
     fireEvent.click(phoneInput.querySelector('.selected-flag'))
@@ -118,7 +118,7 @@ describe('<PhoneInput /> other props', () => {
       <PhoneInput
         country='fr'
         onlyCountries={['fr']}
-        masks={{'fr': '(...) ..-..-..'}}
+        masks={{ 'fr': '(...) ..-..-..' }}
         value='33543773322'
       />)
 
@@ -144,11 +144,11 @@ describe('<PhoneInput /> other props', () => {
       />)
 
     fireEvent.click(phoneInput.querySelector('.selected-flag'))
-    fireEvent.change(phoneInput.querySelector('.search-box'), {target: {value: 'gb'}})
+    fireEvent.change(phoneInput.querySelector('.search-box'), { target: { value: 'gb' } })
     expect(phoneInput.querySelector('.country-list').children.length).toBe(2) // search field & 1 search result
     expect(phoneInput.querySelector('.country-list').children[1].querySelector('.country-name').textContent).toBe('United Kingdom')
   })
-  
+
   test('search "undefined" string returns no non-matching results', () => {
     const { container: phoneInput } = render(
       <PhoneInput
@@ -156,8 +156,17 @@ describe('<PhoneInput /> other props', () => {
       />)
 
     fireEvent.click(phoneInput.querySelector('.selected-flag'))
-    fireEvent.change(phoneInput.querySelector('.search-box'), {target: {value: 'undefined'}})
+    fireEvent.change(phoneInput.querySelector('.search-box'), { target: { value: 'undefined' } })
     expect(phoneInput.querySelector('.no-entries-message')).toBeTruthy()
+  })
+
+  test('testingId renders "data-id" attribute on input for testing', () => {
+    const { container: phoneInput } = render(
+      <PhoneInput
+        data-id="test-phone"
+      />)
+
+    expect(phoneInput.querySelector('.form-control').getAttribute("data-id")).toBe('test-phone')
   })
 })
 


### PR DESCRIPTION
While working on a project, I found that I was unable to pass `data-id` down as a prop to the input value of the component, making it more finicky to run unit and E2E tests on forms where this element, especially multiple forms of this element, existed.

This PR adds `data-id` as a top-level prop, which passes the corresponding value down the core input field the user puts their phone number into.   Typings and Tests were updated as well