### PR TITLE
`typeof null` bugfix for refs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -975,6 +975,9 @@ class PhoneInput extends React.Component {
           {...this.props.inputProps}
           ref={el => {
             this.numberInputRef = el;
+            if (this.props.inputProps.ref == null) {
+              return;
+            }
             if (typeof this.props.inputProps.ref === 'function') {
               this.props.inputProps.ref(el);
             } else if (typeof this.props.inputProps.ref === 'object') {


### PR DESCRIPTION
`else if (typeof this.props.inputProps.ref === 'object')`

Breaks when ref is `null`, as `typeof null` is `'object'`. This commonly happens with `React.forwardRef` so I just added an early return at the beginning to guard against `undefined/null`