### PR TITLE
Added correct formatting for Panama phone numbers

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -946,7 +946,8 @@ const rawCountries = [
     'Panama',
     ['america', 'central-america'],
     'pa',
-    '507'
+    '507',
+    '....-....'
   ],
   [
     'Papua New Guinea',


### PR DESCRIPTION
Hi, I added the formatting for the Panama country phone numbers, here we have two formats
https://en.wikipedia.org/wiki/Telephone_numbers_in_Panama

Telephone numbers format: `xxx-xxxx`
Mobile numbers format: `xxxx-xxxx`

In this case I added just the mobile numbers with 8 digits
