### PR TITLE
Fix dash positioning for Chinese phone numbers

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -264,7 +264,7 @@ const rawCountries = [
     ['asia'],
     'cn',
     '86',
-    '..-.........'
+    '...-........'
   ],
   [
     'Colombia',


### PR DESCRIPTION
For mobile phone numbers in China (by far the most commonly used numbers), the format has the dash after the 3rd digit, not after the 2nd digit. https://en.wikipedia.org/wiki/Telephone_numbers_in_China