### PR TITLE
Change max number length for Côte d'Ivoire

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -303,7 +303,7 @@ const rawCountries = [
     ['africa'],
     'ci',
     '225',
-    '.. .. .. ..'
+    '.. .. .. .. ..'
   ],
   [
     'Croatia',

--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -303,7 +303,7 @@ const rawCountries = [
     ['africa'],
     'ci',
     '225',
-    '.. .. .. .. ..'
+    '.. .. .. ....'
   ],
   [
     'Croatia',


### PR DESCRIPTION
The Autorité de Régulation des Télécommunications/TIC de Côte d’Ivoire (ARTCI), Abidjan, hereby announces the modification of the national numbering plan of Côte d’Ivoire, from eight (8) to ten (10) digits, effective 31 January 2021 in Côte d’Ivoire (country code: 225). More information here https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000310006PDFE.pdf