### PR TITLE
added South Africa format

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -1127,7 +1127,8 @@ const rawCountries = [
     'South Africa',
     ['africa'],
     'za',
-    '27'
+    '27',
+    '... ... ....'
   ],
   [
     'South Korea',


### PR DESCRIPTION
Added the correct format for South Africa


Format | (AB) xxx-xxxx
-- | --


Format	([AB](https://en.wikipedia.org/wiki/Telephone_numbers_in_South_Africa#Number_ranges)) xxx-xxxx