### PR TITLE
Change mask for France from 9 to 10 digits

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -428,7 +428,7 @@ const rawCountries = [
     ['europe', 'eu-union'],
     'fr',
     '33',
-    '. .. .. .. ..'
+    '.. .. .. .. ..'
   ],
   [
     'French Guiana',


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Telephone_numbers_in_France

When calling from abroad, the leading zero is omitted, however "French people usual state phone numbers as a sequence of five double-digit numbers"