### PR TITLE
Update rawCountries.js

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -303,7 +303,7 @@ const rawCountries = [
     ['africa'],
     'ci',
     '225',
-    '.. .. .. ..'
+    '.. .. .. .. ..'
   ],
   [
     'Croatia',


### PR DESCRIPTION
Now, Africa Phone numbers are of length of 10.