### PR TITLE
Update phone number format for Dominican Republic

### DIFF
--- a/src/rawCountries.js
+++ b/src/rawCountries.js
@@ -363,7 +363,7 @@ const rawCountries = [
     ['america', 'carribean'],
     'do',
     '1',
-    '',
+    '(...) ...-....',
     2, ['809', '829', '849']
   ],
   [


### PR DESCRIPTION
Hi! I added the correct phone number format for Dominican Republic, it's just the same as United States format.